### PR TITLE
Fix AV/choice trainers

### DIFF
--- a/kubejs/data/rctmod/trainers/team_allthemods_bored420.json
+++ b/kubejs/data/rctmod/trainers/team_allthemods_bored420.json
@@ -27,7 +27,7 @@
       "dracometeor",
       "hurricane",
       "u-turn",
-      "tailwind"
+      "boomburst"
     ],
     "ivs": {
       "hp": 31,
@@ -51,7 +51,7 @@
     "nature": "modest",
     "ability": "punkrock",
     "moveset": [
-      "overqwil",
+      "voltswitch",
       "thunderbolt",
       "sludgebomb",
       "boomburst"

--- a/kubejs/data/rctmod/trainers/team_allthemods_toblerone0508.json
+++ b/kubejs/data/rctmod/trainers/team_allthemods_toblerone0508.json
@@ -26,8 +26,8 @@
     "moveset": [
       "psyshock",
       "armorcannon",
-      "clearsmog",
-      "calmmind"
+      "shadowball",
+      "energyball"
     ],
     "ivs": {
       "hp": 31,
@@ -135,7 +135,7 @@
       "gigaimpact",
       "zenheadbutt",
       "ironhead",
-      "wideguard"
+      "knockoff"
     ],
     "ivs": {
       "hp": 31,


### PR DESCRIPTION
For mons with AV/choice, remove setup/status moves that would conflict. Also remove overqwil, which is a pokemon not a move