### PR TITLE
Quest Adjustments

### DIFF
--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -1926,6 +1926,7 @@
 				id: "industrialforegoingsouls:soul_laser_base"
 			}
 			id: "79D48F8F31B152C3"
+			optional: true
 			rewards: [
 				{
 					exclude_from_claim_all: true

--- a/config/ftbquests/quests/chapters/pylons.snbt
+++ b/config/ftbquests/quests/chapters/pylons.snbt
@@ -2,7 +2,7 @@
 	default_hide_dependency_lines: false
 	default_quest_shape: ""
 	filename: "pylons"
-	group: "1AC60211DE7427FC"
+	group: "3D4E23B1100491AB"
 	icon: {
 		id: "pylons:infusion_pylon"
 	}

--- a/config/ftbquests/quests/lang/en_us/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/industrial_foregoing.snbt
@@ -26,7 +26,6 @@
 	quest.2580135392DEF522.quest_subtitle: "HNN but for crops?"
 	quest.2580135392DEF522.title: "Simulated Hydroponic Bed"
 	quest.2782EA80C1C74EBD.quest_desc: ["The Mob Crusher &ldeletes&r mobs in its working area, collecting that mob's loot, as well as converting the &aExperience&r that mob would get into &aEssence&r. You can also optionally use the would be Experience to apply Looting to the Mob Crusher instead.\\n\\nBosses and other mobs that cannot go into spawners are \"blacklisted\" from the Mob Crusher. Instead of being &ldeleted&r, they take 75 damage per operation.\\n\\nThis machine supports Range Addons."]
-	quest.2782EA80C1C74EBD.quest_subtitle: ""
 	quest.287B47E27EBC2C18.quest_desc: ["The Enchantment Factory is basically an automated Enchanting Table. When provided with Gear/Books and &aEssence&r, it will enchant that item with something random. This machine can use fluids from tanks directly above it, to allow for an increased potential for enchanting gear and books."]
 	quest.28B3591BFC0FA08B.quest_desc: ["The Wither Builder, as its name implies, builds Withers. It's part of the Wither's Compass for the ATM Star.\\n\\n&8You may want to encase the Wither Builder in some witherproof glass, to prevent Withers from blowing it up."]
 	quest.2CCFEE98FE3B2E97.quest_desc: ["These machines are used to automate block placing/breaking. This is especially useful when automating Latex."]
@@ -108,13 +107,12 @@
 	quest.6E131A32A96D7BF5.quest_desc: ["The Sludge Refiner can use &#5919B6Sludge&r to produce stuff like Dirt, Gravel, Soul Sand...whatever...check JEI for the rest."]
 	quest.6FF04DD735346BED.quest_desc: ["Turns Latex into Dry Rubber. Uses 750 mB of Latex and 500 mB of &9Water&r to produce 1 Dry Rubber."]
 	quest.79D48F8F31B152C3.quest_desc: [
-		"&bIndustrial Foregoing &#27AEB9Souls&r adds machines to allow you to accelerate other machinery.\\n\\nThe &#27AEB9Soul Laser Base&r is the heart of this, working similarly to a Fluid Laser Base extracting Ether Gas from a Wither. It uses &9Blue Laser Lens&r to extract &#27AEB9Souls&r from a &#27AEB9Warden&r, which can be extracted with &#27AEB9Soul Pipes&r, or used with one of the two major digital storage mods (AE2 and RS). These &#27AEB9Souls&r will be used by &#27AEB9Soul Surges&r, in order to accelerate blocks.\\n\\nExtracting &#27AEB9Souls&r from the &#27AEB9Warden&r is a &4&lpainful&r process to the creature, meaning it takes damage from the process, and can even die from it. Stasis Chambers are highly recommended, especially with upgrades to make the healing faster."
+		"&c&lWarning: As of writing, Mewtwo is unobtainable. As a result, the Industrial Foregoing Souls mod has no use at this time.&r\\n\\n&bIndustrial Foregoing &#27AEB9Souls&r adds machines to allow you to accelerate other machinery.\\n\\nThe &#27AEB9Soul Laser Base&r is the heart of this, working similarly to a Fluid Laser Base extracting Ether Gas from a Wither. It uses &9Blue Laser Lens&r to extract &#27AEB9Souls&r from a &#27AEB9Mewtwo&r, which can be extracted with &#27AEB9Soul Pipes&r, or used with AE2. These &#27AEB9Souls&r will be used by &#27AEB9Soul Surges&r, in order to accelerate blocks. Yes, I know most of you are used to extracting &#27AEB9Souls&r from a &#27AEB9Warden&r, but come on, we had to give that thing a break.\\n\\nExtracting &#27AEB9Souls&r from the &#27AEB9Mewtwo&r is a &4&lpainful&r process to the creature, meaning it takes damage from the process, and can even die from it. Stasis Chambers are highly recommended, especially with upgrades to make the healing faster."
 		"{@pagebreak}"
 		"Ensure there's a 3 block gap between the floor and the &#27AEB9Soul Laser Base&r, like so:"
 		"{image:atm:textures/questpics/industrialforegoing/soul_laser_gap.png width:100 height:100 align:center}"
-		"Additionally, ensure the &#27AEB9Warden&r has fully emerged before putting it under stasis."
 	]
-	quest.79D48F8F31B152C3.quest_subtitle: "Gotta go fast!"
+	quest.79D48F8F31B152C3.quest_subtitle: "Gotta go fast! (WIP)"
 	quest.79D48F8F31B152C3.title: "&bIndustrial Foregoing &#27AEB9Souls"
 	quest.7B4AF35313D7D779.quest_subtitle: "Tier: &64"
 	quest.7B4AF35313D7D779.title: "&6Supreme Machine Frame"


### PR DESCRIPTION
Summary of Changes
Mainly just some things I missed with my first quest PR, including learning you need Mewtwo for IFS.
- Industrial Foregoing: Adjusted Industrial Foregoing Souls quest to mention Mewtwo instead of the Warden. As a result, since Mewtwo is not obtainable at this time, I marked this quest as a WIP. Originally I was going to hide it, but I felt like not confusing those who are used to the Warden being used for souls.
- Pylons: Put it back into the Logistics group. This was a leftover from when I ported this chapter from one of my planned 10lite changes, which I failed to notice until now.
