### PR TITLE
Allow master ball to ignore OOB catch restrictions

### DIFF
--- a/kubejs/startup_scripts/catch_restrictions.js
+++ b/kubejs/startup_scripts/catch_restrictions.js
@@ -14,7 +14,9 @@ global.thrownBallHit = (hitEvent) => {
   //console.log("Target Level is: " + targetLevel)
   let battle = hitEvent.pokemon.delegate.battle
   //console.log("Battle is: " + battle)
-  if (battle == null) {
+  let guaranteed = hitEvent.pokeBall.pokeBall.catchRateModifier.isGuaranteed()
+  //console.log("Is guaranteed catch: " + guaranteed)
+  if (battle == null && !guaranteed) {
     let owner = hitEvent.pokeBall.owner
     //console.log("Owner is: " + owner)
     let randomValue = Utils.random.nextFloat()


### PR DESCRIPTION
Uses the isGuaranteed from Cobblemon code to allow the masterball to bypass out of battle checks and other pokéballs that have the guaranteed catch rate (Like the ancient origin ball)

Closes https://github.com/AllTheMods/All-the-Mons/discussions/235