### PR TITLE
Can now look for Poke instead of Poké in JEI

### DIFF
--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -165,6 +165,392 @@ ItemEvents.modifyTooltips(allthemods => {
     allthemods.add('eternal_starlight:loot_bag[eternal_starlight:loot_table="eternal_starlight:bosses/lunar_monstrosity"]', [
         Text.of('This loot bag is from the \"Lunar Monstrosity\".')
     ])
+	
+	//Cobblemon and extras with é in the name
+	allthemods.add('allthemons:token', [
+        Text.of('Also known as PokeToken.')
+    ])
+	allthemods.add('allthemons:valuable_token', [
+        Text.of('Also known as Slightly More Valuable PokeToken.')
+    ])
+	allthemods.add('berrypouch:pokeball_gun', [
+        Text.of('Also known as Pokeball Launcher.')
+    ])
+	allthemods.add('cobblemon:poke_ball', [
+        Text.of('Also known as Poke Ball.')
+    ])
+	allthemods.add('cobblemon:poke_cake', [
+        Text.of('Also known as Poke Cake.')
+    ])
+	allthemods.add('cobblemon:poke_snack', [
+        Text.of('Also known as Poke Snack.')
+    ])
+	allthemods.add('cobblefurnies:poke_ball_desk', [
+        Text.of('Also known as Poke Ball Desk.')
+    ])
+	allthemods.add('cobblefurnies:poke_ball_chair', [
+        Text.of('Also known as Poke Ball Chair.')
+    ])
+	allthemods.add('cobblenav:pokenav_item_base', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblenav:pokenav_item_gholdengo', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblenav:pokenav_item_wanderer', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblenav:pokenav_item_old', [
+		Text.of('Also known as PokeNav.')		
+	])
+	allthemods.add('pkgbadges:poke_fashion_workshop', [
+		Text.of('Also known as PokeFashion Workshop.')		
+	])
+	allthemods.add('cobblemon_utility:poketreat', [
+		Text.of('Also known as Poke Treat.')		
+	])
+	allthemods.add('cobblemon_utility:stalepoketreat', [
+		Text.of('Also known as Stale Poke Treat.')		
+	])
+	//Color variants here. I dont know how to make it in JS, so I just made one by one.
+	//If someone is to refactor this, remember there are less colors of PokeDex and PokeFinders
+	//Colors here: ['white','light_gray','gray','black','brown','red','orange','yellow','lime','green','cyan','light_blue','blue','purple','magenta','pink']
+	allthemods.add('cobblefurnies:white_poke_wool', [
+		Text.of('Also known as White Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:white_poke_wool_carpet', [
+		Text.of('Also known as White Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_white', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:light_gray_poke_wool', [
+		Text.of('Also known as Light gray Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:light_gray_poke_wool_carpet', [
+		Text.of('Also known as Light gray Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_light_gray', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:gray_poke_wool', [
+		Text.of('Also known as Gray Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:gray_poke_wool_carpet', [
+		Text.of('Also known as Gray Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_gray', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:black_poke_wool', [
+		Text.of('Also known as Black Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:black_poke_wool_carpet', [
+		Text.of('Also known as Black Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_black', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:brown_poke_wool', [
+		Text.of('Also known as Brown Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:brown_poke_wool_carpet', [
+		Text.of('Also known as Brown Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_brown', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:red_poke_wool', [
+		Text.of('Also known as Red Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:red_poke_wool_carpet', [
+		Text.of('Also known as Red Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_red', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:orange_poke_wool', [
+		Text.of('Also known as Orange Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:orange_poke_wool_carpet', [
+		Text.of('Also known as Orange Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_orange', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:yellow_poke_wool', [
+		Text.of('Also known as Yellow Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:yellow_poke_wool_carpet', [
+		Text.of('Also known as Yellow Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_yellow', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:lime_poke_wool', [
+		Text.of('Also known as Lime Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:lime_poke_wool_carpet', [
+		Text.of('Also known as Lime Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_lime', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:green_poke_wool', [
+		Text.of('Also known as Green Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:green_poke_wool_carpet', [
+		Text.of('Also known as Green Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_green', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:cyan_poke_wool', [
+		Text.of('Also known as Cyan Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:cyan_poke_wool_carpet', [
+		Text.of('Also known as Cyan Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_cyan', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:light_blue_poke_wool', [
+		Text.of('Also known as Light blue Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:light_blue_poke_wool_carpet', [
+		Text.of('Also known as Light blue Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_light_blue', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:blue_poke_wool', [
+		Text.of('Also known as Blue Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:blue_poke_wool_carpet', [
+		Text.of('Also known as Blue Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_blue', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:purple_poke_wool', [
+		Text.of('Also known as Purple Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:purple_poke_wool_carpet', [
+		Text.of('Also known as Purple Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_purple', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:magenta_poke_wool', [
+		Text.of('Also known as Magenta Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:magenta_poke_wool_carpet', [
+		Text.of('Also known as Magenta Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_magenta', [
+		Text.of('Also known as PokeNav.')
+	])
+	allthemods.add('cobblefurnies:pink_poke_wool', [
+		Text.of('Also known as Pink Poke Wool.')
+	])
+	allthemods.add('cobblefurnies:pink_poke_wool_carpet', [
+		Text.of('Also known as Pink Poke Wool Carpet.')
+	])
+	allthemods.add('cobblenav:pokenav_item_pink', [
+		Text.of('Also known as PokeNav.')
+	])
+	//Colors here ['white','black','red','yellow','green','blue','pink']
+	allthemods.add('cobblemon:pokedex_white', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_white', [
+		Text.of('Also known as PokeFinder.')
+	])
+	allthemods.add('cobblemon:pokedex_black', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_black', [
+		Text.of('Also known as PokeFinder.')
+	])
+	allthemods.add('cobblemon:pokedex_red', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_red', [
+		Text.of('Also known as PokeFinder.')
+	])
+	allthemods.add('cobblemon:pokedex_yellow', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_yellow', [
+		Text.of('Also known as PokeFinder.')
+	])
+	allthemods.add('cobblemon:pokedex_green', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_green', [
+		Text.of('Also known as PokeFinder.')
+	])
+	allthemods.add('cobblemon:pokedex_blue', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_blue', [
+		Text.of('Also known as PokeFinder.')
+	])
+	allthemods.add('cobblemon:pokedex_pink', [
+		Text.of('Also known as Pokedex.')
+	])
+	allthemods.add('cobblenav:pokefinder_item_pink', [
+		Text.of('Also known as PokeFinder.')
+	])
+	//Rod Variants
+	//For refactor, consider these:
+	//['poke','citrine','verdant','azure','roseate','slate','premier','great','ultra','safari','fast','level','lure','heavy','love','friend','moon','sport',
+    //'park','net','dive','nest','repeat','timer','luxury','dusk','heal','quick','dream','beast','master','cherish','ancient_poke','ancient_citrine','ancient_verdant','ancient_azure',
+    // 'ancient_roseate','ancient_slate','ancient_ivory','ancient_great','ancient_ultra','ancient_feather','ancient_wing','ancient_jet','ancient_heavy','ancient_leaden','ancient_gigaton','ancient_origin']
+	allthemods.add('cobblemon:citrine_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:citrine_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:verdant_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:azure_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:roseate_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:slate_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:premier_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:great_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ultra_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:safari_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:fast_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:level_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:lure_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:heavy_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:love_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:friend_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:moon_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:sport_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:park_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:net_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:dive_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:nest_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:repeat_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:timer_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:luxury_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:dusk_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:heal_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:quick_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:dream_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:beast_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:master_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:cherish_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_poke_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_citrine_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_verdant_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_azure_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_roseate_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_slate_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_ivory_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_great_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_ultra_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_feather_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_wing_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_jet_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_heavy_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_leaden_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_gigaton_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
+	allthemods.add('cobblemon:ancient_origin_rod', [
+		Text.of('Also known as Poke Rod.')
+	])
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
Adds tooltips to every item I've found that are cobblemon related so it can be found without using the é.

I just ignored the apotheosis Fabergé and patchouli Poképedia