### PR TITLE
Fix duplicate Productive Bees quest

### DIFF
--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -3610,29 +3610,6 @@
 			hide_dependency_lines: true
 			hide_dependent_lines: true
 			icon: {
-				id: "justdirethings:xp_fluid_bucket"
-			}
-			id: "3D63868AC4393EBC"
-			rewards: [{
-				exclude_from_claim_all: true
-				id: "6A275305D5F779CE"
-				table_id: 6438168168113377309L
-				type: "loot"
-			}]
-			tasks: [{
-				id: "768328EACCBF6754"
-				item: { components: { "productivebees:bee_type": "productivebees:experience" }, count: 1, id: "productivebees:configurable_honeycomb" }
-				match_components: "fuzzy"
-				type: "item"
-			}]
-			x: 1.0d
-			y: 21.0d
-		}
-		{
-			dependencies: ["17419401147B5C02"]
-			hide_dependency_lines: true
-			hide_dependent_lines: true
-			icon: {
 				id: "create_enchantment_industry:super_experience_nugget"
 			}
 			id: "6DF215923418F56F"

--- a/config/ftbquests/quests/lang/en_us/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/lang/en_us/chapters/productive_bees.snbt
@@ -321,8 +321,6 @@
 	quest.3B5095CEDD9FB323.title: "Energized Steel Bee"
 	quest.3CB7AB928D3E1CC6.quest_subtitle: "Made with Energizer"
 	quest.3CB7AB928D3E1CC6.title: "Blazing Crystal Bee"
-	quest.3D63868AC4393EBC.quest_subtitle: "Lapis + Emerald"
-	quest.3D63868AC4393EBC.title: "Experience Bee"
 	quest.3D7480E4F9063E93.quest_subtitle: "Lumber + Sweat"
 	quest.3D7480E4F9063E93.title: "Rancher Bee"
 	quest.3DA5F622E3266AE5.quest_subtitle: "Made in Reprocessor"

--- a/config/ftbquests/quests/lang/ja_jp/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/lang/ja_jp/chapters/productive_bees.snbt
@@ -273,7 +273,6 @@
 	quest.3AF30E1EC163E2E3.title: "サファイアミツバチ"
 	quest.3B5095CEDD9FB323.quest_subtitle: "エナジャイザーで作成"
 	quest.3CB7AB928D3E1CC6.quest_subtitle: "エナジャイザーで作製"
-	quest.3D63868AC4393EBC.quest_subtitle: "ラピスラズリ + エメラルド"
 	quest.3D7480E4F9063E93.quest_subtitle: "ランバー + スウェット"
 	quest.3D7480E4F9063E93.title: "ランチャーミツバチ"
 	quest.3DA5F622E3266AE5.quest_subtitle: "再処理装置で作製"

--- a/config/ftbquests/quests/lang/pt_br/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/lang/pt_br/chapters/productive_bees.snbt
@@ -357,9 +357,6 @@
 	quest.3B5095CEDD9FB323.title: "&fAbelha de Aço Energizado"
 	quest.3CB7AB928D3E1CC6.quest_subtitle: "Feito com energizador"
 	quest.3CB7AB928D3E1CC6.title: "&fAbelha de Cristal Flamejante"
-	quest.3D63868AC4393EBC.quest_desc: ["Uma abelha que dá Fluido de XP do &2Just Dire Things&r."]
-	quest.3D63868AC4393EBC.quest_subtitle: "Lápis + Esmeralda"
-	quest.3D63868AC4393EBC.title: "&fAbelha de Experiência"
 	quest.3D7480E4F9063E93.quest_subtitle: "Madeira + Suor"
 	quest.3D7480E4F9063E93.title: "&fAbelha Fazendeira"
 	quest.3DA5F622E3266AE5.quest_subtitle: "Feito no Reprocessador"


### PR DESCRIPTION
Removed duplicate quest (task 3D63868AC4393EBC). The equivalent quest (task 0FB1FC640471363A) was kept.