### PR TITLE
Make Epitaphs Graves immune to Cataclysm destruction

### DIFF
--- a/kubejs/server_scripts/Tweaks/tags.js
+++ b/kubejs/server_scripts/Tweaks/tags.js
@@ -36,6 +36,9 @@ ServerEvents.tags('block', allthemods => {
 
     // IF Souls
     allthemods.add('industrialforegoingsouls:cant_accelerate', denyTickAcceleration)
+
+    //Make epitaphs immune to Cataclysm block destruction
+    allthemods.add("cataclysm:netherite_monstrosity_immune","epitaphs:grave")
 })
 
 ServerEvents.tags('fluid', allthemods => {


### PR DESCRIPTION
Add immunity for Epitaphs Graves to Cataclysm block destruction by the Netherite Monstrosity.