### PR TITLE
Correctly fix eldritch miner to require unobtainium pickaxe

### DIFF
--- a/kubejs/server_scripts/mods/Occultism/Recipes.js
+++ b/kubejs/server_scripts/mods/Occultism/Recipes.js
@@ -2,7 +2,7 @@
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.recipes(allthemods => {
-    allthemods.remove({ id: 'occultism:ritual/craft_miner_ancient_eldritch' })
+    allthemods.remove({ id: 'occultism:ritual/misc_miner_ancient_eldritch' })
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.


### PR DESCRIPTION
The incorrect ritual was blocked in the KubeJS file, the change is to stop you from bypassing the unobtanium pickaxe + piglich heart.

<img width="1290" height="220" alt="image" src="https://github.com/user-attachments/assets/7a2f4b61-e6c6-4d4f-a94c-54a6017ef4cb" />
<img width="755" height="104" alt="image" src="https://github.com/user-attachments/assets/93f0fbf2-c6b6-4913-b902-764b79fba0c2" />
