### PR TITLE
Scylla and Clawdian Buff

### DIFF
--- a/config/cataclysm-common.toml
+++ b/config/cataclysm-common.toml
@@ -1094,21 +1094,21 @@
 			#Scale mob health by this value
 			# Default: 1.0
 			# Range: 0.1 ~ 1000000.0
-			health_multiplier = 1.0
+			health_multiplier = 22.2
 			#Scale mob attack damage by this value
 			# Default: 1.0
 			# Range: 0.1 ~ 1000000.0
-			attack_multiplier = 1.0
+			attack_multiplier = 18.0
 
 		[mobs.scylla.cap_config]
 			#Damage Cap
 			# Default: 21.0
 			# Range: 0.0 ~ 1000000.0
-			damage_cap = 21.0
+			damage_cap = 210.0
 			#Dps Cap
 			# Default: 13.0
 			# Range: 1.0 ~ 1000000.0
-			dps_cap = 13.0
+			dps_cap = 130.0
 			#DPS Limit Time
 			# Default: 20
 			# Range: 1 ~ 100
@@ -1116,7 +1116,7 @@
 			#Range Cap
 			# Default: 12.0
 			# Range: 1.0 ~ 1000000.0
-			range_cap = 12.0
+			range_cap = 32.0
 
 		[mobs.scylla.respawner_config]
 			#Respawner
@@ -1136,21 +1136,21 @@
 			#Scale mob health by this value
 			# Default: 1.0
 			# Range: 0.1 ~ 1000000.0
-			health_multiplier = 1.0
+			health_multiplier = 10.0
 			#Scale mob attack damage by this value
 			# Default: 1.0
 			# Range: 0.1 ~ 1000000.0
-			attack_multiplier = 1.0
+			attack_multiplier = 9.0
 
 		[mobs.clawdian.cap_config]
 			#Damage Cap
 			# Default: 21.0
 			# Range: 0.0 ~ 1000000.0
-			damage_cap = 21.0
+			damage_cap = 210.0
 			#Dps Cap
 			# Default: 12.0
 			# Range: 1.0 ~ 1000000.0
-			dps_cap = 12.0
+			dps_cap = 120.0
 			#DPS Limit Time
 			# Default: 20
 			# Range: 1 ~ 100
@@ -1158,7 +1158,7 @@
 			#Range Cap
 			# Default: 12.0
 			# Range: 1.0 ~ 1000000.0
-			range_cap = 12.0
+			range_cap = 32.0
 
 		[mobs.clawdian.ignore_mobgriefing_config]
 			#Ignore MobGriefing


### PR DESCRIPTION
Overdue, but it was done.
- Scylla now has x22.2 Base HP (for a total of 8658 HP). She also deals x18 more damage with most attacks. Her damage cap was set to 210, with a DPS Cap of 130
- Clawdian now has x10 base HP (for a total of 2250 HP), and deals x9 more damage. Same damage and DPS caps as Scylla