### PR TITLE
Alternate Sigil of Supremacy "recipe"

### DIFF
--- a/config/cobblemon_battle_tower/bp_shop_items.json
+++ b/config/cobblemon_battle_tower/bp_shop_items.json
@@ -13,6 +13,13 @@
       "bp_cost": 10,
       "item_id": "mega_showdown:mega_stone",
       "quantity": 1
+    },
+	{
+      "id": "sigil_of_supremacy",
+      "display_name": "Sigil of Supremacy",
+      "bp_cost": 100,
+      "item_id": "apotheosis:sigil_of_supremacy",
+      "quantity": 1
     }
   ],
   


### PR DESCRIPTION
Decided on the Battle Tower mainly to evoke a similar feeling as the Endless Gateway of Apothic Invaders, with both being wave based, in a way, plus to involve the Pokémon side of things a bit more with certain aspects of the pack (like making Mewtwo be required for soul surging).
<img width="393" height="65" alt="image" src="https://github.com/user-attachments/assets/56aeff81-d5e9-4e8c-82ac-ca4bf70ccbed" />
