### PR TITLE
[Cross-port] Create Infuser balance changes from ATM-10

### DIFF
--- a/kubejs/server_scripts/mods/Create Enchantment Industry/recipes.js
+++ b/kubejs/server_scripts/mods/Create Enchantment Industry/recipes.js
@@ -1,0 +1,40 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes(allthemods => {
+   if (Item.exists("apotheosis:god_fused_pearl")) {
+    allthemods
+      .shaped(Item.of(`create_enchantment_industry:infuser`), [" B ", " S ", "NGN"], {
+        B: `#c:plates/brass`,
+		S: `create:spout`,
+		N: `create:nixie_tube`,
+		G: `apotheosis:god_fused_pearl`
+      })
+      .id("create_enchantment_industry:crafting/infuser")
+    }
+	else { 
+		allthemods.custom({
+			"type": "apothic_enchanting:infusion",
+			"input": {
+				"item": "create:spout"
+			},
+			"max_requirements": {
+				"arcana": 60.0,
+				"eterna": 100.0,
+				"quanta": 11.0
+			},
+			"requirements": {
+				"arcana": 58.75,
+				"eterna": 100.0,
+				"quanta": 9.65
+			},
+			"result": {
+				"count": 1,
+				"id": "create_enchantment_industry:infuser"
+			}
+		}).id("create_enchantment_industry:crafting/infuser")
+	}
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods - AllTheMods 10.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.


### PR DESCRIPTION
This PR ports the changes from AllTheMods/ATM-10#4255, which was merged after discussion in the ATM-10 repository.

For details on the issue that prompted these changes and the considerations behind the final implementation, please refer to the original PR and its discussion.

The following minimum mod versions are required before this PR can be merged:

- **Apotheosis:** 8.6.1 or later. Version 8.7.0 or later, released on August 2, 2026, is recommended.
- **Apothic Attributes:** 2.10.1 or later.
- **Apothic Enchanting:** 1.6.0 or later.
- **Apothic Spawners:** 1.4.0 or later.
- **Create: Enchantment Industry:** 2.5.0 or later.

After consulting with the original author, @DivineFinal, the fallback code included in the original PR has been omitted from this port. It was originally added to account for the possibility that the required Apotheosis updates might not make their way into the modpack, but we determined that it would most likely not be necessary here.