### PR TITLE
Add ATM10A on README modpack list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# All the Mons
-ATM10 + Cobblemon
-======
+# All the Mons: ATM10 + Cobblemon
+
 This is the official repository and issue-tracker for All The Mons 10 1.21.1
 
 Does "All The Mons" *really* contain ALL THE MONS? No, of course not.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# All the Mons: ATM10 + Cobblemon
+All the Mons: ATM10 + Cobblemon
+======
 
 This is the official repository and issue-tracker for All The Mons 10 1.21.1
 

--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ When reporting an issue, please follow the templates!
 + [![All the Magic Arcana](http://cf.way2muchnoise.eu/1190911.svg "ATMA") All The Magic - Arcana - ATMA](https://www.curseforge.com/minecraft/modpacks/all-the-magic-arcana)
 + [![All the Mods 10 Lite](http://cf.way2muchnoise.eu/1298400.svg "ATM10L") All The Mods 10 Lite - ATM10L](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10-lite)
 + [![All the Mons](http://cf.way2muchnoise.eu/1356598.svg "ATMons") All The Mons - ATMons](https://www.curseforge.com/minecraft/modpacks/all-the-mons)
++ [![All The Mods 10 - Aeronautics Edition](http://cf.way2muchnoise.eu/1644918.svg "ATM10A") All The Mods 10 - Aeronautics Edition - ATM10A](https://www.curseforge.com/minecraft/modpacks/all-the-mods-10-aeronautics)
 + [![All The Mods 11](https://cf.way2muchnoise.eu/1148445.svg "ATM11") All The Mods 11 - ATM11](https://www.curseforge.com/minecraft/modpacks/all-the-mods-11)


### PR DESCRIPTION
Adds ATM10A to the modpack list. The ATM10A abbreviation was confirmed in advance with oly2o6.