### PR TITLE
[Cross-port] Explicitly mark Glyph of Nullify Defense as disabled

### DIFF
--- a/config/ars_elemental/glyph_nullify_defense.toml
+++ b/config/ars_elemental/glyph_nullify_defense.toml
@@ -1,0 +1,27 @@
+#General settings
+[general]
+	#Is Enabled?
+	enabled = false
+	#Cost
+	# Default: 1000
+	# Range: > -2147483648
+	cost = 1000
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	# Default: 2147483647
+	# Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	# Default: 3
+	# Range: 1 ~ 99
+	glyph_tier = 3
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#How much an augment should cost when used on this effect or form. This overrides the default cost in the augment config.
+	#Example entry: "glyph_amplify=50"
+	augment_cost_overrides = []
+	#Prevents the given glyph from being used in the same spell as the given glyph
+	#Example entry: "glyph_burst"
+	invalid_combos = []

--- a/kubejs/client_scripts/RecipeViewer.js
+++ b/kubejs/client_scripts/RecipeViewer.js
@@ -56,6 +56,7 @@ RecipeViewerEvents.removeEntriesCompletely('item', allthemods => {
   allthemods.remove(/mekmm:.*rolling_mill.*/)
 
   allthemods.remove("supplementaries:faucet")
+  allthemods.remove('ars_elemental:glyph_nullify_defense')
 
   allthemods.remove('legendarymonuments:meltan_box')
   allthemods.remove('legendarymonuments:meltan_candy')


### PR DESCRIPTION
This PR is a cross-port of https://github.com/AllTheMods/ATM-10/pull/4372. Please refer to the original PR for details.